### PR TITLE
Moved parsing flags into its own file

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -1,0 +1,45 @@
+package src
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+type Settings struct {
+	Targets     string
+	HTTPS       bool
+	Concurrency int
+	Target      string
+	Timeout     int
+	VerifySSL   bool
+	Emoji       bool
+	HideFails   bool
+}
+
+func PrintHelp() {
+	fmt.Printf("Usage: %s [OPTIONS] argument ...\n", os.Args[0])
+	flag.PrintDefaults()
+	os.Exit(1)
+}
+
+// ParseConfiguration will return the pointer to the populated Settings struct
+func ParseConfiguration() *Settings {
+	opts := Settings{}
+
+	flag.StringVar(&opts.Targets, "targets", "", "File path to list of subdomains to be scanned")
+	flag.BoolVar(&opts.HTTPS, "https", false, "Force https protocol if not no protocol defined for target (default false)")
+	flag.IntVar(&opts.Concurrency, "concurrency", 10, "Number of concurrent checks")
+	flag.StringVar(&opts.Target, "target", "", "Single or multiple subdomains separated by comma")
+	flag.BoolVar(&opts.VerifySSL, "verify_ssl", false, "If set to true it won't check sites with insecure SSL and return HTTP Error")
+	flag.IntVar(&opts.Timeout, "timeout", 10, "Request timeout in seconds")
+	flag.BoolVar(&opts.HideFails, "hide_fails", false, "Don't display failed results")
+
+	flag.Parse()
+
+	if opts.Target == "" && opts.Targets == "" {
+		return nil
+	}
+
+	return &opts
+}

--- a/src/process.go
+++ b/src/process.go
@@ -55,7 +55,7 @@ func processor(subdomainCh chan string, sizeCh chan string, settings *Settings) 
 	for {
 		subdomain := <-subdomainCh
 
-		result := checkSubdomain(subdomain, *settings)
+		result := checkSubdomain(subdomain, settings)
 
 		if result.status == aurora.Green("VULNERABLE") {
 			fmt.Print("-----------------\r\n")

--- a/src/process.go
+++ b/src/process.go
@@ -8,18 +8,7 @@ import (
 	"github.com/logrusorgru/aurora"
 )
 
-type Settings struct {
-	Targets     string
-	Https       bool
-	Concurrency int
-	Target      string
-	Timeout     int
-	VerifySSL   bool
-	Emoji       bool
-	HideFails   bool
-}
-
-func Process(settings Settings) error {
+func Process(settings *Settings) error {
 
 	fingerprints, err := Fingerprints()
 	if err != nil {
@@ -31,7 +20,7 @@ func Process(settings Settings) error {
 	fmt.Println("[ * ]", "Loaded", len(subdomains), "targets")
 	fmt.Println("[ * ]", "Loaded", len(fingerprints), "fingerprints")
 
-	fmt.Println(isEnabled(settings.Https), "HTTPS by default (--https)")
+	fmt.Println(isEnabled(settings.HTTPS), "HTTPS by default (--https)")
 	fmt.Println("[", settings.Concurrency, "]", "Concurrent requests (--concurrency)")
 	fmt.Println(isEnabled(settings.VerifySSL), "Check target only if SSL is valid (--verify_ssl)")
 	fmt.Println("[", settings.Timeout, "]", "HTTP request timeout (in seconds) (--timeout)")
@@ -62,11 +51,11 @@ func isEnabled(setting bool) string {
 	return "[ No ]"
 }
 
-func processor(subdomainCh chan string, sizeCh chan string, settings Settings) {
+func processor(subdomainCh chan string, sizeCh chan string, settings *Settings) {
 	for {
 		subdomain := <-subdomainCh
 
-		result := checkSubdomain(subdomain, settings)
+		result := checkSubdomain(subdomain, *settings)
 
 		if result.status == aurora.Green("VULNERABLE") {
 			fmt.Print("-----------------\r\n")
@@ -90,7 +79,7 @@ func generator(subdomain string, subdomainCh chan string) {
 	subdomainCh <- subdomain
 }
 
-func getSubdomains(settings Settings) []string {
+func getSubdomains(settings *Settings) []string {
 	if settings.Target == "" {
 		subdomains, err := readSubdomains(settings.Targets)
 		if err != nil {

--- a/src/worker.go
+++ b/src/worker.go
@@ -19,7 +19,7 @@ type Result struct {
 func checkSubdomain(subdomain string, settings Settings) Result {
 
 	if isValidUrl(subdomain) == false {
-		if settings.Https {
+		if settings.HTTPS {
 			subdomain = "https://" + subdomain
 		} else {
 			subdomain = "http://" + subdomain

--- a/src/worker.go
+++ b/src/worker.go
@@ -16,7 +16,7 @@ type Result struct {
 	entry  Fingerprint
 }
 
-func checkSubdomain(subdomain string, settings Settings) Result {
+func checkSubdomain(subdomain string, settings *Settings) Result {
 
 	if isValidUrl(subdomain) == false {
 		if settings.HTTPS {
@@ -67,7 +67,7 @@ func isValidUrl(toTest string) bool {
 	}
 }
 
-func httpClient(settings Settings) *http.Client {
+func httpClient(settings *Settings) *http.Client {
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: !settings.VerifySSL},

--- a/subzy.go
+++ b/subzy.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"flag"
-	"fmt"
 	"log"
-	"os"
 
 	"github.com/lukasikic/subzy/src"
 )
@@ -13,22 +10,10 @@ func main() {
 
 	src.CheckFingerprints()
 
-	settings := src.Settings{}
+	settings := src.ParseConfiguration()
 
-	flag.StringVar(&settings.Targets, "targets", "", "File path to list of subdomains to be scanned")
-	flag.BoolVar(&settings.Https, "https", false, "Force https protocol if not no protocol defined for target (default false)")
-	flag.IntVar(&settings.Concurrency, "concurrency", 10, "Number of concurrent checks")
-	flag.StringVar(&settings.Target, "target", "", "Single or multiple subdomains separated by comma")
-	flag.BoolVar(&settings.VerifySSL, "verify_ssl", false, "If set to true it won't check sites with insecure SSL and return HTTP Error")
-	flag.IntVar(&settings.Timeout, "timeout", 10, "Request timeout in seconds")
-	flag.BoolVar(&settings.HideFails, "hide_fails", false, "Don't display failed results")
-
-	flag.Parse()
-
-	if settings.Target == "" && settings.Targets == "" {
-		fmt.Printf("Usage: %s [OPTIONS] argument ...\n", os.Args[0])
-		flag.PrintDefaults()
-		os.Exit(2)
+	if settings == nil {
+		src.PrintHelp()
 	}
 
 	if err := src.Process(settings); err != nil {


### PR DESCRIPTION
This PR adds the file `src/config.go` which parses the flag and cleans the `subzy.go` package more. 

Also, changed the usage of `Settings` object with `*Settings` as it is more lightweight to use.