### PR TITLE
Replaced the fingerprint string of Pantheon

### DIFF
--- a/src/fingerprints.json
+++ b/src/fingerprints.json
@@ -247,7 +247,7 @@
   {
     "Engine": "Pantheon",
     "Status": "Vulnerable",
-    "Fingerprint": "404 error unknown site!",
+    "Fingerprint": "The gods are wise, but do not know of the site which you seek.",
     "Discussion": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/24",
     "Documentation": "https://medium.com/@hussain_0x3c/hostile-subdomain-takeover-using-pantheon-ebf4ab813111"
   },


### PR DESCRIPTION
Added a relevant fingerprint string for Pantheon. Below if the default error for Pantheon which displays the string I replaced in the .json file:

![Screenshot from 2022-10-25 19-16-14](https://user-images.githubusercontent.com/37262788/197839751-527f50d3-d934-42a3-a08c-1fd2d4029ddd.png)
